### PR TITLE
fix: exit the ignore condition when '*/' is found

### DIFF
--- a/lexical-analyzer/prog.dl
+++ b/lexical-analyzer/prog.dl
@@ -1,7 +1,9 @@
 programa soma inicio
+	/*    Declarada a variável "a" */
 	inteiro a;
 	inteiro b;
 	inteiro c;
+	
 	a = 5;
 	b = 3;
 	c = a + b;

--- a/lexical-analyzer/src/lexer/Lexer.java
+++ b/lexical-analyzer/src/lexer/Lexer.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Hashtable;
+import java.util.concurrent.Callable;
 
 public class Lexer {
 	private static final char EOF_CHAR = (char) -1;
@@ -85,6 +86,12 @@ public class Lexer {
 			return new Token(Tag.MUL, "*");
 		case '/':
 			nextChar();
+			if (peek == '*') {
+				while (peek != '/')
+					nextChar();
+				nextChar();
+				break;
+			}
 			return new Token(Tag.DIV, "/");
 		case '|':
 			nextChar();


### PR DESCRIPTION
Currently, the break inside the switch is causing an unexpected behavior, where the character is being returned as a UNK token, which means the character is part of an unknown pattern.